### PR TITLE
Deployment preparation debug: deployment module error

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,12 @@
     "react": "^17.0.2",
     "react-bootstrap": "^2.1.2",
     "react-dom": "^17.0.2",
-    "sharp": "^0.31.0"
+    "dotenv": "^15.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.16.12",
     "@babel/plugin-transform-react-jsx": "^7.16.7",
     "babel-loader": "^8.2.3",
-    "dotenv": "^15.0.1",
     "eslint": "^7.29.0",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-html": "^6.1.2",


### PR DESCRIPTION
Updated 'package.json' to move 'dotenv' from 'devDependencies' to 'dependencies' to debug dokku deployment module error message.
