### PR TITLE
Bug: Twitter Summary Card with Large Image not rendering image.

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -17,7 +17,18 @@
     property="og:image"
     content="https://city-canvas.laveirge.dev/city-canvas-images/assets/og-image.webp"
   />
+  <meta
+    property="og:image:alt"
+    content="Image of mural in Livorno titled 'Wisteria Flowers' by artist
+    Ligama. Mural depicts four people of various backgrounds, including the
+    artist. One of them is blowing wisteria flowers out of her palm at the
+    blindfolded artist."
+  />
   <meta name="twitter:card" content="summary_large_image">
+  <meta
+    name="twitter:image"
+    content="https://city-canvas.laveirge.dev/city-canvas-images/assets/og-image.webp"
+  />
   <meta
     name="twitter:image:alt"
     content="Image of mural in Livorno titled 'Wisteria Flowers' by artist


### PR DESCRIPTION
Updated the meta tags in the head element on 'index.html' to include twitter's image meta tag and open graph's 'image:alt' meta tag to test if that is keeping the twitter previews from rendering the image. #47

![image](https://user-images.githubusercontent.com/85596835/213601160-d38484f8-d6dd-46ff-9a15-b9c7eda3e0a0.png)
